### PR TITLE
解决前端跨域问题

### DIFF
--- a/Web/hotpoints/src/utils/request.js
+++ b/Web/hotpoints/src/utils/request.js
@@ -2,7 +2,7 @@ import axios from "axios";
 
 // axios实例
 const instance = axios.create({
-    baseURL: 'http://127.0.0.1:8000',
+    baseURL: '/api',
     timeout: 300000
 })
 

--- a/Web/hotpoints/vue.config.js
+++ b/Web/hotpoints/vue.config.js
@@ -1,4 +1,15 @@
 const { defineConfig } = require('@vue/cli-service')
 module.exports = defineConfig({
   transpileDependencies: true,
+  devServer: {
+    proxy: {
+      '/api': {
+        target: 'http://127.0.0.1:8000', //请求后台接口
+        changeOrigin: true, // 允许跨域
+        pathRewrite: {
+          '^/api': '' // 重写请求
+        }
+      }
+    }
+  }
 })


### PR DESCRIPTION
使用vue服务器代理，通过vue服务器收发网络请求，回避浏览器的跨域策略。